### PR TITLE
Notify only when spotted

### DIFF
--- a/Lib/cConfig.py
+++ b/Lib/cConfig.py
@@ -69,7 +69,7 @@ class cConfig:
 
     class cNotification:
         ENABLED:                      bool
-        CONDITION:                    list[str]   # list[Literal['goals', 'targets', 'friends']]
+        CONDITION:                    list[str]   # list[Literal['goals', 'targets', 'friends', 'spotted']]
         RENOTIFICATION_DELAY_SECONDS: int
     NOTIFICATION = cNotification
 
@@ -205,8 +205,8 @@ class cConfig:
                 conditions = cCommon.Split(notification['CONDITION'])
 
                 for condition in conditions:
-                    if condition not in ['goals', 'targets', 'friends']:
-                        print(f"NOTIFICATION CONDITION '{condition}' must be 'goals' and/or 'targets' and/or 'friends'")
+                    if condition not in ['goals', 'targets', 'friends', 'spotted']:
+                        print(f"NOTIFICATION CONDITION '{condition}' must be 'goals' and/or 'targets' and/or 'friends' and/or 'spotted'")
                         sys.exit()
 
                 self.NOTIFICATION.CONDITION = conditions

--- a/skcc_skimmer.py
+++ b/skcc_skimmer.py
@@ -531,7 +531,7 @@ class cRBN_Filter(cRBN_Client):
 
         return Zulu, Spotter, FrequencyKHz, CallSign, CallSignSuffix, dB, WPM
 
-    def HandleNotification(self, CallSign: str, GoalList: list[str], TargetList: list[str]) -> Literal['+', ' ']:
+    def HandleNotification(self, CallSign: str, GoalList: list[str], TargetList: list[str], SpottedNearby: bool) -> Literal['+', ' ']:
         NotificationFlag = ' '
 
         Now = time.time()
@@ -542,7 +542,7 @@ class cRBN_Filter(cRBN_Client):
 
         if CallSign not in self.Notified:
             if config.NOTIFICATION.ENABLED:
-                if (CallSign in config.FRIENDS and 'friends' in config.NOTIFICATION.CONDITION) or (GoalList and 'goals' in config.NOTIFICATION.CONDITION) or (TargetList and 'targets' in config.NOTIFICATION.CONDITION):
+                if (CallSign in config.FRIENDS and 'friends' in config.NOTIFICATION.CONDITION) or (GoalList and 'goals' in config.NOTIFICATION.CONDITION) or (TargetList and 'targets' in config.NOTIFICATION.CONDITION) or (SpottedNearby and 'spotted' in config.NOTIFICATION.CONDITION):
                     Beep()
 
             NotificationFlag = '+'
@@ -680,11 +680,11 @@ class cRBN_Filter(cRBN_Client):
             '''
 
             if CallSign == 'K3Y':
-                NotificationFlag = self.HandleNotification(f'K3Y/{CallSignSuffix}', GoalList, TargetList)
+                NotificationFlag = self.HandleNotification(f'K3Y/{CallSignSuffix}', GoalList, TargetList, SpottedNearby)
                 Out = f'{Zulu}{NotificationFlag}K3Y/{CallSignSuffix} on {FrequencyString:>8} {"; ".join(Report)}'
             else:
                 MemberInfo = BuildMemberInfo(CallSign)
-                NotificationFlag = self.HandleNotification(CallSign, GoalList, TargetList)
+                NotificationFlag = self.HandleNotification(CallSign, GoalList, TargetList, SpottedNearby)
                 Out = f'{Zulu}{NotificationFlag}{CallSign:<6} {MemberInfo} on {FrequencyString:>8} {"; ".join(Report)}'
 
             Display.Print(Out)


### PR DESCRIPTION
This change adds a `spotted` condition for notifications. This allows to only notify when the callsign has been spotted by the RBN, reducing noise by focusing on only nearby spotted calls.